### PR TITLE
refactor: use `XDG` base directory for all paths

### DIFF
--- a/pywal16
+++ b/pywal16
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-ln -sf ~/.cache/wal/colors.Xresources ~/.Xresources
-cat ~/.Xresources ~/.cache/wal/xrdb_extra | xrdb -merge
+ln -sf $XDG_CACHE_HOME/wal/colors.Xresources $XDG_CONFIG_HOME/x11/xresources
+cat $XDG_CONFIG_HOME/x11/xresources $XDG_CACHE_HOME/wal/xrdb_extra | xrdb -merge
 xdotool key super+F5 # xrdb refresh keybind
 
 notify-send "New wallpaper just dropped"

--- a/set-wallpaper
+++ b/set-wallpaper
@@ -3,7 +3,7 @@
 # slightly scuffed wallpaper picker menu for use with pywal - uses nsxiv if installed, otherwise uses dmenu
 
 FOLDER="$HOME/wallpapers/" # wallpaper folder
-SCRIPT="$HOME/scripts/pywal16" # script to run after wal for refreshing programs, etc.
+SCRIPT="$XDG_CONFIG_HOME/scripts/pywal16" # script to run after wal for refreshing programs, etc.
 
 
 menu() {


### PR DESCRIPTION
This PR refactors all the scripts in the repository to use the [XDG Base Directory](https://wiki.archlinux.org/title/XDG_Base_Directory) specification for paths, ensuring better system organization and compatibility with user-defined environments.

### Changes:
- Updated all scripts in the repo to use `$XDG_CACHE_HOME`, `$XDG_CONFIG_HOME`, and other relevant XDG environment variables, instead of hardcoded paths like `~/.cache` and `~/.config`.

#### Additional Notes:
If you’re setting up your environment to fully use the XDG Base Directory, you might also want to ensure the XDG environment variables are configured.

For setting these up, check out the related [repository with .zprofile](https://github.com/eoSalinas/dots/blob/main/.zprofile) where these variables can be set globally.
